### PR TITLE
Fix build failure when archiving

### DIFF
--- a/DocumentController.xcodeproj/project.pbxproj
+++ b/DocumentController.xcodeproj/project.pbxproj
@@ -216,6 +216,7 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../../node_modules/react-native/React/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
App was failing with error "'RCTBridgeModule.h' file not found" when trying to archive for release.

This fixes it.